### PR TITLE
additional logic for configurable stream names for models

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -13,7 +13,7 @@ abstract class Model implements \JsonSerializable
     /**
      * @var array
      */
-    public $excludeProperties = ['filters', 'excludeProperties', 'rawData', 'bulk', 'topic'];
+    public $excludeProperties = ['filters', 'excludeProperties', 'rawData', 'bulk', 'topic', 'stream'];
 
     /**
      * @var array
@@ -25,6 +25,10 @@ abstract class Model implements \JsonSerializable
      */
     public $bulk = false;
 
+    /**
+     * @param $value
+     * @return string
+     */
     public function getJsonObjectValue($value)
     {
         if ($value instanceof \DateTime) {

--- a/src/Model/ModelTrait/CacheCreateTrait.php
+++ b/src/Model/ModelTrait/CacheCreateTrait.php
@@ -39,7 +39,7 @@ trait CacheCreateTrait
 
         try {
             if ($this instanceof MessageInterface) {
-                $this->publishMessage($this->getObjectName(), $this->createMessage());
+                $this->publishMessage($this->getObjectName(), $this->getStreamName(), $this->createMessage());
             }
         } catch (\Exception $exception) {
             if ($this instanceof DeleteInterface) {

--- a/src/Model/ModelTrait/CreateTrait.php
+++ b/src/Model/ModelTrait/CreateTrait.php
@@ -2,6 +2,7 @@
 namespace NYPL\Starter\Model\ModelTrait;
 
 use NYPL\Starter\APIException;
+use NYPL\Starter\Config;
 use NYPL\Starter\Model\LocalDateTime;
 
 trait CreateTrait
@@ -29,6 +30,14 @@ trait CreateTrait
         $reflection = new \ReflectionClass($this);
 
         return $reflection->getShortName();
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getStreamName()
+    {
+        return Config::get('DEFAULT_STREAM');
     }
 
     /**

--- a/src/Model/ModelTrait/DBCreateTrait.php
+++ b/src/Model/ModelTrait/DBCreateTrait.php
@@ -45,7 +45,7 @@ trait DBCreateTrait
 
         try {
             if ($this instanceof MessageInterface && !$this->isBulk()) {
-                $this->publishMessage($this->getObjectName(), $this->createMessage());
+                $this->publishMessage($this->getObjectName(), $this->getStreamName(), $this->createMessage());
             }
         } catch (\Exception $exception) {
             if ($this instanceof DeleteInterface) {

--- a/src/Model/ModelTrait/MessageTrait.php
+++ b/src/Model/ModelTrait/MessageTrait.php
@@ -14,6 +14,11 @@ trait MessageTrait
     protected $topic = '';
 
     /**
+     * @var string
+     */
+    protected $stream = '';
+
+    /**
      * @var KinesisClient
      */
     protected static $client;
@@ -25,15 +30,17 @@ trait MessageTrait
 
     /**
      * @param string $topic
+     * @param string $stream
      * @param string $message'
      *
      * @throws \InvalidArgumentException
      */
-    protected function publishMessage($topic = '', $message = '')
+    protected function publishMessage($topic = '', $stream = '', $message = '')
     {
         $this->setTopic($topic);
+        $this->setStream($stream);
 
-        $this->publishMessageAsKinesis($topic, $message);
+        $this->publishMessageAsKinesis($stream, $message);
     }
 
     /**
@@ -51,6 +58,9 @@ trait MessageTrait
             if (!$this->getTopic()) {
                 $this->setTopic($model->getObjectName());
             }
+            if (!$this->getStream()) {
+                $this->setStream($model->getStreamName());
+            }
 
             $records[] =  [
                 'Data' => $model->createMessage(),
@@ -60,21 +70,21 @@ trait MessageTrait
 
         self::getClient()->putRecords([
             'Records' => $records,
-            'StreamName' => $this->getTopic()
+            'StreamName' => $this->getStream()
         ]);
     }
 
     /**
-     * @param string $topic
+     * @param string $stream
      * @param string $message
      * @throws \InvalidArgumentException
      */
-    protected function publishMessageAsKinesis($topic = '', $message = '')
+    protected function publishMessageAsKinesis($stream = '', $message = '')
     {
         self::getClient()->putRecord([
             'Data' => $message,
             'PartitionKey' => uniqid(),
-            'StreamName' => $topic
+            'StreamName' => $stream
         ]);
     }
 
@@ -175,5 +185,21 @@ trait MessageTrait
     public function setTopic($topic)
     {
         $this->topic = $topic;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStream()
+    {
+        return $this->stream;
+    }
+
+    /**
+     * @param string $stream
+     */
+    public function setStream($stream)
+    {
+        $this->stream = $stream;
     }
 }

--- a/src/Model/Source.php
+++ b/src/Model/Source.php
@@ -9,10 +9,19 @@ class Source extends Model
 {
     use TranslateTrait, DBCreateTrait;
 
+    /**
+     * @var string
+     */
     public $id = '';
 
+    /**
+     * @var string
+     */
     public $sourceCode = '';
 
+    /**
+     * @var string
+     */
     public $sourceId = '';
 
     /**
@@ -20,14 +29,28 @@ class Source extends Model
      */
     private $createdDate;
 
+    /**
+     * @return string
+     */
     public function getIdName()
     {
         return "id";
     }
 
+    /**
+     * @return string
+     */
     public function getSequenceId()
     {
         return "source_id_seq";
+    }
+
+    /**
+     * @return string
+     */
+    public function getStreamName()
+    {
+        return 'Source';
     }
 
     /**


### PR DESCRIPTION
Attempt at providing a way to allow a configurable stream name which can be based on the Model name with additional environment parameters if needed. This tries to follow the same logic as exists for the sequence and id fields. It adds an additional parameter to the publishMessage() method for a stream name along with a topic name which is used by Avro decoding.

Please review and let me know what you think. I'm sure there are many ways to produce the same result, but this is my attempt. :)