### PR TITLE
chg DBUpdateTrait to use getStreamName

### DIFF
--- a/src/Model/ModelTrait/DBUpdateTrait.php
+++ b/src/Model/ModelTrait/DBUpdateTrait.php
@@ -33,7 +33,7 @@ trait DBUpdateTrait
         $this->read();
 
         if ($this instanceof MessageInterface && !$this->isBulk()) {
-            $this->publishMessage($this->getObjectName(), $this->createMessage());
+            $this->publishMessage($this->getStreamName(), $this->createMessage());
         }
     }
 


### PR DESCRIPTION
Looks like the only update to master needs the DBUpdateTrait fixed to use getStreamName. CacheUpdateTrait already uses this method.