### PR TITLE
Should we include JSON content type in header?

### DIFF
--- a/src/APIClient.php
+++ b/src/APIClient.php
@@ -13,11 +13,18 @@ abstract class APIClient
     protected $client;
 
     protected $isRequiresAuth = false;
+    
+    protected $isRequiresJSON = false;
 
     /**
      * @return bool
      */
     abstract protected function isRequiresAuth();
+    
+    /**
+     * @return bool
+     */
+    abstracted protected function isRequiresJSON();
 
     /**
      * @param array $options
@@ -28,6 +35,10 @@ abstract class APIClient
     {
         if ($this->isRequiresAuth()) {
             $options['headers']['Authorization'] = 'Bearer ' . OAuthClient::getAccessToken();
+        }
+        
+        if ($this->isRequiresJSON()) {
+            $options['headers']['Content-type'] = 'application/json';
         }
 
         return $options;


### PR DESCRIPTION
Hi @kfriedman, 

@gkallenberg and I were working on `CancelRequestResultConsumer` and I got stuck on `https://api.nypltech.org/v0.1/recap/cancel-hold-requests` return 405 Method Not Allowed. Last time we solve that problem by adding `application/json` Content-type to the header, but that code only resides on my own APIClient class in my `hold-request-result-consumer` repo. Is it possible to include `application/json` as an optional header? The following is suggested edits. Thanks!