### PR TITLE
SCC-4729: Adds urlencode to fopen string so that it doesn't strip plus signs.

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -100,7 +100,7 @@ abstract class Controller
     public function getJsonResponse($data): MessageInterface
     {
         $json = json_encode($data);
-        $streamBody = fopen('data://text/plain,' . $json, 'r');
+        $streamBody = fopen('data://text/plain,' . urlencode($json), 'r');
         return $this->getResponse()->withBody(new Stream($streamBody));
     }
 


### PR DESCRIPTION
Jira Ticket: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4729

The fopen command takes a "data://text/plain" URL as its input, and as such, it treats plus signs as spaces. I added "urlencode" to the string to keep that from happening.