### PR TITLE
Use error code from exception if provided

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -17,12 +17,19 @@ class ErrorHandler
     public static function processShutdownError($errorString = '', $context = [])
     {
         if (!self::isIgnoreError()) {
+            $errorCode = 500;
+            if ($context instanceof \Throwable) {
+              $exceptionCode = $context->getCode();
+              if ($exceptionCode >= 400 && $exceptionCode <= 599) {
+                $errorCode = $exceptionCode;
+              }
+            }
             $exception = new APIException($errorString, $context);
 
             APILogger::addError($errorString, $exception);
 
             $apiResponse = new ErrorResponse(
-                500,
+                $errorCode,
                 'error',
                 $errorString,
                 $exception
@@ -32,7 +39,7 @@ class ErrorHandler
                 ob_clean();
             }
 
-            http_response_code(500);
+            http_response_code($errorCode);
             header('Content-Type: application/json');
             header('Access-Control-Allow-Origin: *');
             echo json_encode($apiResponse, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);


### PR DESCRIPTION
* This is for https://newyorkpubliclibrary.atlassian.net/browse/SCC-5259 so we can actually tell when we have a 404 from the item service or an internal server error.
* Item service passes ALL exceptions into this [here](https://github.com/NYPL-discovery/itemservice/blob/development/index.php#L90) and every exception regardless of code is treated as a 500. That makes it impossible to discern in places like the HoldRequestConsumer [here](https://github.com/NYPL/nypl-hold-request-consumer/blob/development/index.js#L253) whether an error is recoverable or non-recoverable.
* This causes issues like the one we saw in Feb where the lambda gets stuck processing hold requests 