### PR TITLE
Fix bug reading exception http code

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -19,7 +19,7 @@ class ErrorHandler
         if (!self::isIgnoreError()) {
             $errorCode = 500;
             if ($context instanceof \Throwable) {
-              $exceptionCode = $context->getCode();
+              $exceptionCode = $context->getHttpCode();
               if ($exceptionCode >= 400 && $exceptionCode <= 599) {
                 $errorCode = $exceptionCode;
               }


### PR DESCRIPTION
The error "code" is 0, but the "http code" is 404 in the context of a missing record.